### PR TITLE
fix forgotten backward incompatibility

### DIFF
--- a/src/MAPI/Message/Attachment.php
+++ b/src/MAPI/Message/Attachment.php
@@ -103,7 +103,7 @@ class Attachment extends AttachmentItem
 
     public function isValid()
     {
-        return (count($this->properties) > 0);
+        return $this->properties !== null;
     }
 
     public function __get($name)


### PR DESCRIPTION
[There](https://github.com/hfig/MAPI/blob/2025d1a23abd4d2f4eccc4898cb4ed8f0a733c6b/src/MAPI/Message/Attachment.php#L106) is an error on PHP 7.2 because of a [backward incompatible change](http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types) when counting non-countable types.