### PR TITLE
Remove call to substr when parsing PT_MV_CLSID

### DIFF
--- a/src/MAPI/Property/PropertyStore.php
+++ b/src/MAPI/Property/PropertyStore.php
@@ -332,7 +332,7 @@ class PropertyStore
 
                 case '0048':    // PT_CLSID 
                 case '1048':    // PT_MV_CLSID
-                    $value = (string)OleGuid::fromBytes(substr($rawProp, 8));
+                    $value = (string)OleGuid::fromBytes($rawProp);
                     $this->addProperty($key, $value);
                     break;
 


### PR DESCRIPTION
Remove call to substr when parsing PT_MV_CLSID because it wasn't returning enough bytes for a UUID and was throwing Ramsey\Uuid\Exception\InvalidUuidStringException .