### PR TITLE
Separate PT_CLSID from PT_MV_CLSID

### DIFF
--- a/src/MAPI/Property/PropertyStore.php
+++ b/src/MAPI/Property/PropertyStore.php
@@ -331,6 +331,10 @@ class PropertyStore
                     break;
 
                 case '0048':    // PT_CLSID 
+                    $value = (string)OleGuid::fromBytes($rawProp);
+                    $this->addProperty($key, $value);
+                    break;
+
                 case '1048':    // PT_MV_CLSID
                     $value = (string)OleGuid::fromBytes(substr($rawProp, 8));
                     $this->addProperty($key, $value);


### PR DESCRIPTION
PT_CLSID and PT_MV_CLSID have different structures.
PT_CLSID doesn't have a COUNT field in front of it so it doesn't need the call to substr() to trim the leading bytes.
When PT_CLSID was encountered it would throw a Ramsey\Uuid\Exception\InvalidUuidStringException because
the UUID was too short.
Reference to fields:
https://web.archive.org/web/20160814154216/http://www.imibo.com/LazyMAPI/MAPIPropTypesList.aspx