### PR TITLE
update symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-mbstring": "*",
         "pear/ole": "^1.0.0RC5",
         "pear/pear-core-minimal": "^1.10",
-        "symfony/yaml": "^4.1",
+        "symfony/yaml": "^4.1 || ^5.0",
         "ramsey/uuid": "^3.8 || ^4.0",
         "psr/log": "^1.0"
     },


### PR DESCRIPTION
I updated symfony/yaml, still allowing the old one for projects that are locked onto it.

This project uses only the `Yaml::parseFile` method which didn't change from v4 to v5 (last documented change to it was in 4.4.0).