### PR TITLE
added getter for properties to Message class

### DIFF
--- a/src/MAPI/Message/Message.php
+++ b/src/MAPI/Message/Message.php
@@ -211,6 +211,11 @@ class Message extends MessageItem
         return \DateTime::createFromFormat('U',$sendTime);
     }
 
+    public function properties(): PropertySet
+    {
+	return $this->properties;
+    }
+	
     public function __get($name)
     {
         if ($name == 'properties') {


### PR DESCRIPTION
Accessing the properties of a message via `$message->properties` is confusing for devs and is marked as an error in IDEs as the `properties` attribute is protected. A getter method is a more clear way to allow read-only access to this property.