### PR TITLE
fixed incompatible call

### DIFF
--- a/src/MAPI/OLE/Pear/DocumentElement.php
+++ b/src/MAPI/OLE/Pear/DocumentElement.php
@@ -187,7 +187,7 @@ class DocumentElement implements CompoundDocumentElement
 
         // nasty Pear_OLE actually writes out a temp file and fpassthru's on it. Yuck.
         // so let's give a wrapped stream which ignores Pear_OLE's fopen() and fclose()
-        $wrappedStreamUrl = StreamWrapper::wrapStream($stream);
+        $wrappedStreamUrl = StreamWrapper::wrapStream($stream, 'r');
         $root->save($wrappedStreamUrl);
 
         /*ob_start();


### PR DESCRIPTION
Not sure, if this is the right solution, but it works for us. We are only reading the Outlook MSG files.