### PR TITLE
Make package available for php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Pure PHP library for reading and manipulating Microsoft Outlook .msg messages (MAPI documents)",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1||^8.0",
         "ext-bcmath": "*",
         "ext-mbstring": "*",
         "pear/ole": "^1.0.0RC8",


### PR DESCRIPTION
Since the package seems to be completely compatible with PHP 8 I went ahead and added PHP 8 support in composer. This is currently preventing us upgrading to PHP 8.

<img width="652" alt="Screenshot 2021-03-17 at 14 58 56" src="https://user-images.githubusercontent.com/1062751/111479732-889bef00-8731-11eb-80f5-6bf4ce5f0a4d.png">
