### PR TITLE
Skip undefined array key

### DIFF
--- a/src/MAPI/Property/PropertyStore.php
+++ b/src/MAPI/Property/PropertyStore.php
@@ -152,6 +152,8 @@ class PropertyStore
 
             //# a bit sus
             $guid_off = $flags >> 1;
+            if (!isset($guids[$guid_off - 2]))
+                return;
             $guid = $guids[$guid_off - 2];
 
             /*$properties[] = [


### PR DESCRIPTION
Hi,

This is a bugfix for [issuse 26](https://github.com/hfig/MAPI/issues/26) 