### PR TITLE
Solving conversion of mails with Swiftmailer - The Second

### DIFF
--- a/src/MAPI/Mime/Swiftmailer/Factory.php
+++ b/src/MAPI/Mime/Swiftmailer/Factory.php
@@ -8,8 +8,19 @@ use Hfig\MAPI\OLE\CompoundDocumentElement as Element;
 
 class Factory implements ConversionFactory
 {
+
+    protected $muteConversionExceptions;
+
+    public function __construct(bool $muteConversionExceptions = false)
+    {
+        $this->muteConversionExceptions = $muteConversionExceptions;
+    }
+
     public function parseMessage(Element $root)
-    {        
-        return new \Hfig\MAPI\Mime\Swiftmailer\Message($root);
+    {
+        $message = new \Hfig\MAPI\Mime\Swiftmailer\Message($root);
+        $message->setMuteConversionExceptions($this->muteConversionExceptions);
+
+        return $message;
     }
 }

--- a/src/MAPI/Mime/Swiftmailer/Message.php
+++ b/src/MAPI/Mime/Swiftmailer/Message.php
@@ -35,24 +35,44 @@ class Message extends BaseMessage implements MimeConvertible
 
         // add them to the message
         $add = [$message, 'setTo']; // function
-        $this->addRecipientHeaders('To', $headers, $add);
+        try {
+            $this->addRecipientHeaders('To', $headers, $add);
+        }
+        catch (\Exception $e) {}
         $headers->unset('To');
 
         $add = [$message, 'setCc']; // function
-        $this->addRecipientHeaders('Cc', $headers, $add);
+        try {
+            $this->addRecipientHeaders('Cc', $headers, $add);
+        }
+        catch (\Exception $e) {}
         $headers->unset('Cc');
 
         $add = [$message, 'setBcc']; // function
-        $this->addRecipientHeaders('Bcc', $headers, $add);
+        try {
+            $this->addRecipientHeaders('Bcc', $headers, $add);
+        }
+        catch (\Exception $e) {}
         $headers->unset('Bcc');
 
         $add = [$message, 'setFrom']; // function
-        $this->addRecipientHeaders('From', $headers, $add);
+        try {
+            $this->addRecipientHeaders('From', $headers, $add);
+        }
+        catch (\Exception $e) {}
         $headers->unset('From');
 
 
-        $message->setId(trim($headers->getValue('Message-ID'), '<>'));
-        $message->setDate(new \DateTime($headers->getValue('Date')));
+        try {
+            $message->setId(trim($headers->getValue('Message-ID'), '<>'));
+        }
+        catch (\Exception $e) {}
+
+        try {
+            $message->setDate(new \DateTime($headers->getValue('Date')));
+        }
+        catch (\Exception $e) {}
+
         if ($boundary = $this->getMimeBoundary($headers)) {
             $message->setBoundary($boundary);
         }
@@ -97,7 +117,10 @@ class Message extends BaseMessage implements MimeConvertible
             if ($bodyBoundary) {
                 $multipart->setBoundary($bodyBoundary);
             }
-            $multipart->setBody($this->getBody(), 'text/plain');
+            try {
+                $multipart->setBody($this->getBody(), 'text/plain');
+            }
+            catch (\Exception $e) {}
 
             $part = new \Swift_MimePart($html, 'text/html', null);
             $part->setEncoder($message->getEncoder());

--- a/src/MAPI/Mime/Swiftmailer/Message.php
+++ b/src/MAPI/Mime/Swiftmailer/Message.php
@@ -12,7 +12,6 @@ use Hfig\MAPI\Mime\Swiftmailer\Adapter\DependencySet;
 
 class Message extends BaseMessage implements MimeConvertible
 {
-	protected $conversionExceptionsList = [];
 
     public static function wrap(BaseMessage $message)
     {
@@ -23,10 +22,8 @@ class Message extends BaseMessage implements MimeConvertible
         return new self($message->obj, $message->parent);
     }
     
-    public function toMime(bool $muteConversionExceptions = false)
+    public function toMime()
     {
-    	$this->conversionExceptionsList = [];
-
         DependencySet::register();
 
         $message = new \Swift_Message();
@@ -41,72 +38,42 @@ class Message extends BaseMessage implements MimeConvertible
         try {
             $this->addRecipientHeaders('To', $headers, $add);
         }
-        catch (\Swift_RfcComplianceException $e) {
-        	if (!$muteConversionExceptions) {
-        		throw $e;
-			}
-        	$this->conversionExceptionsList[] = $e;
-		}
+        catch (\Exception $e) {}
         $headers->unset('To');
 
         $add = [$message, 'setCc']; // function
         try {
             $this->addRecipientHeaders('Cc', $headers, $add);
         }
-        catch (\Swift_RfcComplianceException $e) {
-			if (!$muteConversionExceptions) {
-				throw $e;
-			}
-			$this->conversionExceptionsList[] = $e;
-		}
+        catch (\Exception $e) {}
         $headers->unset('Cc');
 
         $add = [$message, 'setBcc']; // function
         try {
             $this->addRecipientHeaders('Bcc', $headers, $add);
         }
-        catch (\Swift_RfcComplianceException $e) {
-			if (!$muteConversionExceptions) {
-				throw $e;
-			}
-			$this->conversionExceptionsList[] = $e;
-		}
+        catch (\Exception $e) {}
         $headers->unset('Bcc');
 
         $add = [$message, 'setFrom']; // function
         try {
             $this->addRecipientHeaders('From', $headers, $add);
         }
-        catch (\Swift_RfcComplianceException $e) {
-			if (!$muteConversionExceptions) {
-				throw $e;
-			}
-			$this->conversionExceptionsList[] = $e;
-		}
+        catch (\Exception $e) {}
         $headers->unset('From');
 
 
         try {
             $message->setId(trim($headers->getValue('Message-ID'), '<>'));
         }
-        catch (\Swift_RfcComplianceException $e) {
-			if (!$muteConversionExceptions) {
-				throw $e;
-			}
-			$this->conversionExceptionsList[] = $e;
-		}
+        catch (\Exception $e) {}
 
         try {
             $message->setDate(new \DateTime($headers->getValue('Date')));
         }
-        catch (\Exception $e) { // the \DateTime can throw \Exception
-			if (!$muteConversionExceptions) {
-				throw $e;
-			}
-			$this->conversionExceptionsList[] = $e;
-		}
+        catch (\Exception $e) {}
 
-		if ($boundary = $this->getMimeBoundary($headers)) {
+        if ($boundary = $this->getMimeBoundary($headers)) {
             $message->setBoundary($boundary);
         }
 
@@ -134,23 +101,12 @@ class Message extends BaseMessage implements MimeConvertible
                 $hasHtml = true;
             }
         }
-        catch (\Exception $e) { // getBodyHTML() can throw \Exception
-			if (!$muteConversionExceptions) {
-				throw $e;
-			}
-			$this->conversionExceptionsList[] = $e;
+        catch (\Exception $e) {
+            // ignore invalid HTML body
         }
 
         if (!$hasHtml) {
-			try {
-            	$message->setBody($this->getBody(), 'text/plain');
-			}
-			catch (\Exception $e) { // getBody() can throw \Exception
-				if (!$muteConversionExceptions) {
-					throw $e;
-				}
-				$this->conversionExceptionsList[] = $e;
-			}
+            $message->setBody($this->getBody(), 'text/plain');
         }
         else {
             // build multi-part
@@ -164,12 +120,7 @@ class Message extends BaseMessage implements MimeConvertible
             try {
                 $multipart->setBody($this->getBody(), 'text/plain');
             }
-            catch (\Exception $e) { // getBody() can throw \Exception
-				if (!$muteConversionExceptions) {
-					throw $e;
-				}
-				$this->conversionExceptionsList[] = $e;
-			}
+            catch (\Exception $e) {}
 
             $part = new \Swift_MimePart($html, 'text/html', null);
             $part->setEncoder($message->getEncoder());
@@ -191,15 +142,15 @@ class Message extends BaseMessage implements MimeConvertible
         return $message;
     }
 
-    public function toMimeString(bool $muteConversionExceptions = false): string
+    public function toMimeString(): string
     {
-        return (string)$this->toMime($muteConversionExceptions);
+        return (string)$this->toMime();
     }
 
-    public function copyMimeToStream($stream, bool $muteConversionExceptions = false)
+    public function copyMimeToStream($stream)
     {
         // TODO: use \Swift_Message::toByteStream instead
-        fwrite($stream, $this->toMimeString($muteConversionExceptions));
+        fwrite($stream, $this->toMimeString());
     }
 
     protected function addRecipientHeaders($field, HeaderCollection $headers, callable $add)
@@ -363,12 +314,4 @@ class Message extends BaseMessage implements MimeConvertible
         return '';
     }
 
-	/**
-	 * Returns the list of conversion exceptions from the call of toMime() with the $muteConversionExceptions = true.
-	 *
-	 * @return array
-	 */
-    public function getConversionExceptionsList() : array {
-    	return $this->conversionExceptionsList;
-	}
 }

--- a/src/MAPI/Mime/Swiftmailer/Message.php
+++ b/src/MAPI/Mime/Swiftmailer/Message.php
@@ -12,6 +12,7 @@ use Hfig\MAPI\Mime\Swiftmailer\Adapter\DependencySet;
 
 class Message extends BaseMessage implements MimeConvertible
 {
+    protected $conversionExceptionsList = [];
 
     public static function wrap(BaseMessage $message)
     {
@@ -22,8 +23,10 @@ class Message extends BaseMessage implements MimeConvertible
         return new self($message->obj, $message->parent);
     }
     
-    public function toMime()
+    public function toMime(bool $muteConversionExceptions = false)
     {
+        $this->conversionExceptionsList = [];
+
         DependencySet::register();
 
         $message = new \Swift_Message();
@@ -38,40 +41,69 @@ class Message extends BaseMessage implements MimeConvertible
         try {
             $this->addRecipientHeaders('To', $headers, $add);
         }
-        catch (\Exception $e) {}
+        catch (\Swift_RfcComplianceException $e) {
+            if (!$muteConversionExceptions) {
+                throw $e;
+            }
+            $this->conversionExceptionsList[] = $e;
+        }
         $headers->unset('To');
 
         $add = [$message, 'setCc']; // function
         try {
             $this->addRecipientHeaders('Cc', $headers, $add);
         }
-        catch (\Exception $e) {}
+        catch (\Swift_RfcComplianceException $e) {
+            if (!$muteConversionExceptions) {
+                throw $e;
+            }
+            $this->conversionExceptionsList[] = $e;
+        }
         $headers->unset('Cc');
 
         $add = [$message, 'setBcc']; // function
         try {
             $this->addRecipientHeaders('Bcc', $headers, $add);
         }
-        catch (\Exception $e) {}
+        catch (\Swift_RfcComplianceException $e) {
+            if (!$muteConversionExceptions) {
+                throw $e;
+            }
+            $this->conversionExceptionsList[] = $e;}
         $headers->unset('Bcc');
 
         $add = [$message, 'setFrom']; // function
         try {
             $this->addRecipientHeaders('From', $headers, $add);
         }
-        catch (\Exception $e) {}
+        catch (\Swift_RfcComplianceException $e) {
+            if (!$muteConversionExceptions) {
+                throw $e;
+            }
+            $this->conversionExceptionsList[] = $e;
+        }
         $headers->unset('From');
 
 
         try {
             $message->setId(trim($headers->getValue('Message-ID'), '<>'));
         }
-        catch (\Exception $e) {}
+        catch (\Swift_RfcComplianceException $e) {
+            if (!$muteConversionExceptions) {
+                throw $e;
+            }
+            $this->conversionExceptionsList[] = $e;
+        }
 
         try {
             $message->setDate(new \DateTime($headers->getValue('Date')));
         }
-        catch (\Exception $e) {}
+        catch (\Exception $e) { // the \DateTime can throw \Exception
+            if (!$muteConversionExceptions) {
+                throw $e;
+            }
+            $this->conversionExceptionsList[] = $e;
+        }
 
         if ($boundary = $this->getMimeBoundary($headers)) {
             $message->setBoundary($boundary);
@@ -101,12 +133,23 @@ class Message extends BaseMessage implements MimeConvertible
                 $hasHtml = true;
             }
         }
-        catch (\Exception $e) {
-            // ignore invalid HTML body
+        catch (\Exception $e) { // getBodyHTML() can throw \Exception
+            if (!$muteConversionExceptions) {
+                throw $e;
+            }
+            $this->conversionExceptionsList[] = $e;
         }
 
         if (!$hasHtml) {
-            $message->setBody($this->getBody(), 'text/plain');
+            try {
+                $message->setBody($this->getBody(), 'text/plain');
+            }
+            catch (\Exception $e) { // getBody() can throw \Exception
+                if (!$muteConversionExceptions) {
+                    throw $e;
+                }
+                $this->conversionExceptionsList[] = $e;
+            }
         }
         else {
             // build multi-part
@@ -120,7 +163,12 @@ class Message extends BaseMessage implements MimeConvertible
             try {
                 $multipart->setBody($this->getBody(), 'text/plain');
             }
-            catch (\Exception $e) {}
+            catch (\Exception $e) { // getBody() can throw \Exception
+                if (!$muteConversionExceptions) {
+                    throw $e;
+                }
+                $this->conversionExceptionsList[] = $e;
+            }
 
             $part = new \Swift_MimePart($html, 'text/html', null);
             $part->setEncoder($message->getEncoder());
@@ -142,15 +190,15 @@ class Message extends BaseMessage implements MimeConvertible
         return $message;
     }
 
-    public function toMimeString(): string
+    public function toMimeString(bool $muteConversionExceptions = false): string
     {
-        return (string)$this->toMime();
+        return (string)$this->toMime($muteConversionExceptions);
     }
 
-    public function copyMimeToStream($stream)
+    public function copyMimeToStream($stream, bool $muteConversionExceptions = false)
     {
         // TODO: use \Swift_Message::toByteStream instead
-        fwrite($stream, $this->toMimeString());
+        fwrite($stream, $this->toMimeString($muteConversionExceptions));
     }
 
     protected function addRecipientHeaders($field, HeaderCollection $headers, callable $add)
@@ -314,4 +362,12 @@ class Message extends BaseMessage implements MimeConvertible
         return '';
     }
 
+    /**
+     * Returns the list of conversion exceptions from the call of toMime() with the $muteConversionExceptions = true.
+     *
+     * @return array
+     */
+    public function getConversionExceptionsList() : array {
+        return $this->conversionExceptionsList;
+    }
 }


### PR DESCRIPTION
We had issues with exceptions preventing parsing of faulty msg files - and we are in need of an option to have a lossy conversion instead on no conversion in such cases. So here is a new PR as the initial one has been stale for a while.

I took the changes @risototh kindly provided in their PR (https://github.com/hfig/MAPI/pull/24) and refactored it with changes @hfig suggested in their comment (https://github.com/hfig/MAPI/pull/24#issuecomment-860141464).

TLDR:  you can now set a property to the `Factory` class to define if the exceptions in `$message->toMime()` method are being muted like this: 
```php
$messageFactory = new MAPI\MapiMessageFactory(new Swiftmailer\Factory(muteConversionExceptions: true));
```