### PR TITLE
Update symfony/yaml to 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-mbstring": "*",
         "pear/ole": "^1.0.0RC8",
         "pear/pear-core-minimal": "^1.10",
-        "symfony/yaml": "^4.1||^5.0||^6.0",
+        "symfony/yaml": "^4.1||^5.0||^6.0||^7.0",
         "ramsey/uuid": "^3.8||^4.0",
         "psr/log": "^1.0||^2.0||^3.0"
     },


### PR DESCRIPTION
Years after #13, I perpetuate the tradition.
I've updated symfony/yaml to allow this library to be used in conjunction with 7.x.

