### PR TITLE
Add returntypes where possible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     },
     "require-dev": {
         "swiftmailer/swiftmailer": "^6.1",
-        "phpunit/phpunit": "^8.3"
+        "phpunit/phpunit": "^8.3",
+        "pear/pear-core-minimal": "^1.10"
     },
     "suggest": {
         "swiftmailer/swiftmailer": "Conversion to MIME (eml file) message format"  

--- a/src/MAPI/Item/Attachment.php
+++ b/src/MAPI/Item/Attachment.php
@@ -25,7 +25,7 @@ abstract class Attachment extends MapiObject
         fwrite($stream, $this->getData() ?? '');
     }
 
-    protected function storeEmbeddedOle($stream)
+    protected function storeEmbeddedOle($stream): void
     {
         // this is very untested...
         //throw new \RuntimeException('Saving an OLE Compound Document is not supported');

--- a/src/MAPI/Message/Attachment.php
+++ b/src/MAPI/Message/Attachment.php
@@ -97,7 +97,7 @@ class Attachment extends AttachmentItem
         return $this->properties['attach_content_id'] ?? null;
     }
 
-    public function getEmbeddedOleData()
+    public function getEmbeddedOleData(): ?string
     {
         $compobj = $this->properties["\01CompObj"];
         if (is_null($compobj)) {
@@ -106,7 +106,7 @@ class Attachment extends AttachmentItem
         return substr($compobj, 32);
     }
 
-    public function isValid()
+    public function isValid(): bool
     {
         return $this->properties !== null;
     }

--- a/src/MAPI/Message/Message.php
+++ b/src/MAPI/Message/Message.php
@@ -88,18 +88,18 @@ class Message extends MessageItem
     }
 
     /** @return Attachment[] */
-    public function getAttachments()
+    public function getAttachments(): array
     {
         return $this->attachments;
     }
 
     /** @return  Recipient[] */
-    public function getRecipients()
+    public function getRecipients(): array
     {
         return $this->recipients;
     }
 
-    public function getRecipientsOfType($type)
+    public function getRecipientsOfType($type): array
     {
         $response = [];
         foreach ($this->recipients as $r) {

--- a/src/MAPI/Mime/HeaderCollection.php
+++ b/src/MAPI/Mime/HeaderCollection.php
@@ -6,12 +6,12 @@ class HeaderCollection implements \IteratorAggregate
 {
     protected $rawHeaders = [];
 
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->rawHeaders);
     }
     
-    public function add($header, $value = null)
+    public function add($header, $value = null): void
     {
         if (is_null($value)) {
             //echo $header . "\n";
@@ -40,7 +40,7 @@ class HeaderCollection implements \IteratorAggregate
         }
     }
 
-    public function set($header, $value)
+    public function set($header, $value): void
     {
         $key = strtolower($header);
         $val = [
@@ -77,13 +77,13 @@ class HeaderCollection implements \IteratorAggregate
 
     }
 
-    public function has($header) 
+    public function has($header): bool
     {
         $key = strtolower($header);
         return isset($this->rawHeaders[$key]);
     }
 
-    public function unset($header) 
+    public function unset($header): void
     {
         $key = strtolower($header);
         unset($this->rawHeaders[$key]);

--- a/src/MAPI/Mime/Swiftmailer/Adapter/DependencySet.php
+++ b/src/MAPI/Mime/Swiftmailer/Adapter/DependencySet.php
@@ -8,7 +8,7 @@ use \Swift_DependencyContainer;
 class DependencySet {
 
     // override the HeaderFactory registration in the DI container
-    public static function register($force = false)
+    public static function register($force = false): void
     {
         static $registered = false;
 

--- a/src/MAPI/Mime/Swiftmailer/Adapter/HeaderFactory.php
+++ b/src/MAPI/Mime/Swiftmailer/Adapter/HeaderFactory.php
@@ -22,7 +22,7 @@ class HeaderFactory extends Swift_Mime_SimpleHeaderFactory
         $this->charset = $charset;
     }
 
-    public function createTextHeader($name, $value = null)
+    public function createTextHeader($name, $value = null): UnstructuredHeader
     {
         $header = new UnstructuredHeader($name, $this->encoder);
         if (isset($value)) {
@@ -33,7 +33,7 @@ class HeaderFactory extends Swift_Mime_SimpleHeaderFactory
         return $header;
     }
 
-    protected function setHeaderCharset(Swift_Mime_Header $header)
+    protected function setHeaderCharset(Swift_Mime_Header $header): void
     {
         if (isset($this->charset)) {
             $header->setCharset($this->charset);

--- a/src/MAPI/Mime/Swiftmailer/Adapter/UnstructuredHeader.php
+++ b/src/MAPI/Mime/Swiftmailer/Adapter/UnstructuredHeader.php
@@ -18,7 +18,7 @@ class UnstructuredHeader extends Swift_Mime_Headers_UnstructuredHeader
      *
      * @return bool
      */
-    protected function tokenNeedsEncoding($token)
+    protected function tokenNeedsEncoding($token): bool
     {
         static $prevToken = '';
 

--- a/src/MAPI/Mime/Swiftmailer/Attachment.php
+++ b/src/MAPI/Mime/Swiftmailer/Attachment.php
@@ -17,7 +17,7 @@ class Attachment extends BaseAttachment implements MimeConvertible
         return new self($attachment->obj, $attachment->parent);
     }
 
-    public function toMime()
+    public function toMime(): \Swift_Attachment
     {
         DependencySet::register();
 
@@ -67,7 +67,7 @@ class Attachment extends BaseAttachment implements MimeConvertible
         return (string)$this->toMime();
     }
 
-    public function copyMimeToStream($stream)
+    public function copyMimeToStream($stream): void
     {
         fwrite($stream, $this->toMimeString());
     }

--- a/src/MAPI/Mime/Swiftmailer/Factory.php
+++ b/src/MAPI/Mime/Swiftmailer/Factory.php
@@ -16,9 +16,9 @@ class Factory implements ConversionFactory
         $this->muteConversionExceptions = $muteConversionExceptions;
     }
 
-    public function parseMessage(Element $root)
+    public function parseMessage(Element $root): Message
     {
-        $message = new \Hfig\MAPI\Mime\Swiftmailer\Message($root);
+        $message = new Message($root);
         $message->setMuteConversionExceptions($this->muteConversionExceptions);
 
         return $message;

--- a/src/MAPI/Mime/Swiftmailer/Message.php
+++ b/src/MAPI/Mime/Swiftmailer/Message.php
@@ -24,7 +24,7 @@ class Message extends BaseMessage implements MimeConvertible
         return new self($message->obj, $message->parent);
     }
 
-    public function toMime()
+    public function toMime(): \Swift_Message
     {
         DependencySet::register();
 

--- a/src/MAPI/OLE/Guid/OleGuid.php
+++ b/src/MAPI/OLE/Guid/OleGuid.php
@@ -11,7 +11,7 @@ class OleGuid
     /** @var UuidFactory */
     private static $factory = null;
 
-    protected static function getFactory()
+    protected static function getFactory(): UuidFactory
     {
         if (!self::$factory) {
             self::$factory = new UuidFactory();

--- a/src/MAPI/OLE/Pear/DocumentElement.php
+++ b/src/MAPI/OLE/Pear/DocumentElement.php
@@ -32,7 +32,7 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->No;
     }
 
-    public function setIndex($index)
+    public function setIndex($index): void
     {
         $this->pps->No = $index;
     }
@@ -42,12 +42,12 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->Name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->pps->Name = $name;
     }
 
-    public function getType()
+    public function getType(): ?int
     {
         static $map = [
             OLE_PPS_TYPE_ROOT =>  CompoundDocumentElement::TYPE_ROOT,
@@ -58,7 +58,7 @@ class DocumentElement implements CompoundDocumentElement
         return $map[$this->pps->Type] ?? null;
     }
 
-    public function setType($type)
+    public function setType($type): void
     {
         static $map = [
             CompoundDocumentElement::TYPE_ROOT => OLE_PPS_TYPE_ROOT,
@@ -73,17 +73,17 @@ class DocumentElement implements CompoundDocumentElement
         $this->pps->Type = $map[$type];
     }
 
-    public function isDirectory() 
+    public function isDirectory(): bool
     {
         return ($this->getType() == CompoundDocumentElement::TYPE_DIRECTORY);
     }
 
-    public function isFile() 
+    public function isFile(): bool
     {
         return ($this->getType() == CompoundDocumentElement::TYPE_FILE);
     }
 
-    public function isRoot() 
+    public function isRoot(): bool
     {
         return ($this->getType() == CompoundDocumentElement::TYPE_ROOT);
     }
@@ -93,7 +93,7 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->PrevPps;
     }
 
-    public function setPreviousIndex($index)
+    public function setPreviousIndex($index): void
     {
         $this->pps->PrevPps = $index;
     }
@@ -103,7 +103,7 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->NextPps;
     }
 
-    public function setNextIndex($index)
+    public function setNextIndex($index): void
     {
         $this->pps->NextPps = $index;
     }
@@ -113,7 +113,7 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->DirPps;
     }
 
-    public function setFirstChildIndex($index)
+    public function setFirstChildIndex($index): void
     {
         $this->pps->DirPps = $index;
     }
@@ -123,7 +123,7 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->Time1st;
     }
 
-    public function setTimeCreated($time)
+    public function setTimeCreated($time): void
     {
         $this->pps->Time1st = $time;
     }
@@ -133,7 +133,7 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->Time2nd;
     }
 
-    public function setTimeModified($time)
+    public function setTimeModified($time): void
     {
         $this->pps->Time2nd = $time;
     }
@@ -149,15 +149,12 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps->Size;
     }
 
-    public function setSize($size)
+    public function setSize($size): void
     {
         $this->pps->Size = $size;
     }
 
-    /**
-     * @return DocumentElementCollection
-     */
-    public function getChildren()
+    public function getChildren(): DocumentElementCollection
     {
         //if (!$this->wrappedChildren) {
         //    $this->wrappedChildren = new DocumentElementCollection($this->ole, $this->pps->Children);
@@ -179,7 +176,7 @@ class DocumentElement implements CompoundDocumentElement
         return $this->pps;
     }
 
-    public function saveToStream($stream)
+    public function saveToStream($stream): void
     {
         
 

--- a/src/MAPI/OLE/Pear/DocumentElementCollection.php
+++ b/src/MAPI/OLE/Pear/DocumentElementCollection.php
@@ -21,7 +21,7 @@ class DocumentElementCollection implements \ArrayAccess, \IteratorAggregate
         $this->ole = $ole;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         foreach ($this->col as $k => $v)
         {
@@ -29,11 +29,15 @@ class DocumentElementCollection implements \ArrayAccess, \IteratorAggregate
         }
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->col[$offset]);
     }
 
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!isset($this->col[$offset])) {
@@ -47,7 +51,7 @@ class DocumentElementCollection implements \ArrayAccess, \IteratorAggregate
         return $this->proxy_col[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (!$value instanceof DocumentElement) {
             throw new \InvalidArgumentException('Collection must contain DocumentElement instances');
@@ -57,7 +61,7 @@ class DocumentElementCollection implements \ArrayAccess, \IteratorAggregate
         $this->col[$offset] = $value->unwrap();
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->proxy_col[$offset]);
         unset($this->col[$offset]);

--- a/src/MAPI/OLE/Pear/StreamWrapper.php
+++ b/src/MAPI/OLE/Pear/StreamWrapper.php
@@ -15,7 +15,7 @@ class StreamWrapper
 
     private static $handles = [];
 
-    public static function wrapStream($stream, $mode)
+    public static function wrapStream($stream, $mode): string
     {
         self::register();
 
@@ -26,9 +26,11 @@ class StreamWrapper
         $key = key(self::$handles);
 
         return 'olewrap://stream/' . (string)$key;
-
     }
 
+    /**
+     * @return resource
+     */
     public static function createStreamContext($stream)
     {
         return stream_context_create([
@@ -36,7 +38,7 @@ class StreamWrapper
         ]);
     }
 
-    public static function register()
+    public static function register(): void
     {
         if (!in_array('olewrap', stream_get_wrappers())) {
             stream_wrapper_register('olewrap', __CLASS__);
@@ -49,7 +51,7 @@ class StreamWrapper
     }
 
 
-    public function stream_open($path, $mode, $options, &$opened_path) 
+    public function stream_open($path, $mode, $options, &$opened_path): bool
     { 
         $url = parse_url($path);
         $streampath = [];
@@ -80,7 +82,7 @@ class StreamWrapper
         return false;
     }
 
-    public function stream_read($count)
+    public function stream_read($count): string
     {
         // always read a block to satisfy the buffer
         $this->buffer = fread($this->stream, 8192);
@@ -89,33 +91,42 @@ class StreamWrapper
         return substr($this->buffer, 0, $count);
     }
 
+    /**
+     * @return false|int
+     */
     public function stream_write($data)
     {
         return fwrite($this->stream, $data);
     }
 
+    /**
+     * @return false|int
+     */
     public function stream_tell()
     {
         return ftell($this->stream);
     }
 
-    public function stream_eof()
+    public function stream_eof(): bool
     {
         return feof($this->stream);
     }
 
-    public function stream_seek($offset, $whence)
+    public function stream_seek($offset, $whence): int
     {
         //echo 'seeking on parent stream (' . $offset . '  ' . $whence . ')'."\n";
         return fseek($this->stream, $offset, $whence);
     }
 
+    /**
+     * @return array|false
+     */
     public function stream_stat()
     {
         return fstat($this->stream);
     }
 
-    public function url_stat($path, $flags)
+    public function url_stat($path, $flags): array
     {
         return [
             'dev'     => 0,

--- a/src/MAPI/OLE/RTF/CompressionCodec.php
+++ b/src/MAPI/OLE/RTF/CompressionCodec.php
@@ -4,16 +4,16 @@ namespace Hfig\MAPI\OLE\RTF;
 
 class CompressionCodec
 {
-    const DICT = "{\\rtf1\\ansi\\mac\\deff0\\deftab720{\\fonttbl;}" .
+    public const DICT = "{\\rtf1\\ansi\\mac\\deff0\\deftab720{\\fonttbl;}" .
                    "{\\f0\\fnil \\froman \\fswiss \\fmodern \\fscript ".
                    "\\fdecor MS Sans SerifSymbolArialTimes New RomanCourier" .
                    "{\\colortbl\\red0\\green0\\blue0\n\r\\par " .
                    "\\pard\\plain\\f0\\fs20\\b\\i\\u\\tab\\tx";
-    const BLOCKSIZE = 4096;
-    const HEADERSIZE = 16;
+    public const BLOCKSIZE = 4096;
+    public const HEADERSIZE = 16;
 
     // this is adapted from Java libpst instead of Ruby ruby-msg
-    static private function uncompress($raw, $compressedSize, $uncompressedSize)
+    private static function uncompress($raw, $compressedSize, $uncompressedSize): string
     {
         $buf = str_pad(self::DICT, self::BLOCKSIZE, "\0");
         $wp  = strlen(self::DICT);
@@ -71,8 +71,7 @@ class CompressionCodec
         return $data;
     }
 
-
-    static public function decode($data)
+    public static function decode($data): string
     {
         
         $result = '';
@@ -80,7 +79,7 @@ class CompressionCodec
         //echo 'Len: ' . strlen($data), "\n";
 
         $header = array_values(unpack('Vcs/Vus/a4m/Vcrc', $data));
-        list($compressedSize, $uncompressedSize, $magic, $crc32) = $header;
+        [$compressedSize, $uncompressedSize, $magic, $crc32] = $header;
 
         if ($magic == 'MELA') {
             $data = substr($data, self::HEADERSIZE, $uncompressedSize);
@@ -96,8 +95,12 @@ class CompressionCodec
 
     }
 
-    // see Kopano-core Mapi4Linux or Python delimitry/compressed_rtf
-    static public function encode($data)
+    /**
+     * @comment see Kopano-core Mapi4Linux or Python delimitry/compressed_rtf
+     *
+     * @return false|string
+     */
+    public static function encode($data)
     {
         $uncompressedSize = strlen($data);
         $compressedSize = $uncompressedSize + self::HEADERSIZE;

--- a/src/MAPI/OLE/RTF/EmbeddedHTML.php
+++ b/src/MAPI/OLE/RTF/EmbeddedHTML.php
@@ -7,7 +7,7 @@ class EmbeddedHTML
     // the fact that this seems to work is rather amazing because it's a horrid mess!
     // the proper format is specified by [MS-OXRTFEX]
 
-    public static function extract($data)
+    public static function extract($data): string
     {
         if ($pos = strpos($data, '{\*\htmltag') === false) {
             return '';

--- a/src/MAPI/OLE/RTF/StringScanner.php
+++ b/src/MAPI/OLE/RTF/StringScanner.php
@@ -63,7 +63,7 @@ class StringScanner
         return false;
     }
 
-    public function eos()
+    public function eos(): bool
     {
         return $this->pos >= strlen($this->buffer);
     }

--- a/src/MAPI/Property/PropertyCollection.php
+++ b/src/MAPI/Property/PropertyCollection.php
@@ -6,13 +6,13 @@ class PropertyCollection implements \IteratorAggregate
 {
     private $col = [];
 
-    public function set(PropertyKey $key, $value)
+    public function set(PropertyKey $key, $value): void
     {
         //echo sprintf('Setting for %s %s'."\n", $key->getCode(), $key->getGuid());
         $this->col[$key->getHash()] = ['key' => $key, 'value' => $value];
     }
 
-    public function delete(PropertyKey $key)
+    public function delete(PropertyKey $key): void
     {
         unset($this->col[$key->getHash()]);
     }
@@ -26,26 +26,26 @@ class PropertyCollection implements \IteratorAggregate
         return $bucket['value'];
     }
 
-    public function has(PropertyKey $key)
+    public function has(PropertyKey $key): bool
     {
         return isset($this->col[$key->getHash()]);
     }
 
-    public function keys()
+    public function keys(): array
     {
         return array_map(function($bucket) {
             return $bucket['key'];
         }, $this->col);
     }
 
-    public function values()
+    public function values(): array
     {
         return array_map(function($bucket) {
             return $bucket['value'];
         }, $this->col);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         foreach ($this->col as $bucket) {
             yield $bucket['key'] => $bucket['value'];

--- a/src/MAPI/Property/PropertyKey.php
+++ b/src/MAPI/Property/PropertyKey.php
@@ -22,7 +22,7 @@ class PropertyKey {
         //echo '  Created with code ' . $code . "\n";
     }
 
-    public function getHash()
+    public function getHash(): string
     {
         return static::getHashOf($this->code, $this->guid);
     }
@@ -37,7 +37,7 @@ class PropertyKey {
         return $this->guid;
     }
 
-    public static function getHashOf($code, $guid = null)
+    public static function getHashOf($code, $guid = null): string
     {
         if (!$guid) {
             $guid = PropertySetConstants::PS_MAPI();

--- a/src/MAPI/Property/PropertySet.php
+++ b/src/MAPI/Property/PropertySet.php
@@ -32,7 +32,7 @@ class PropertySet implements \ArrayAccess
     
     }
 
-    private static function init()
+    private static function init(): void
     {
         self::$tagsMsg   = Yaml::parseFile(self::SCHEMA_DIR . '/MapiFieldsMessage.yaml');
         self::$tagsOther = Yaml::parseFile(self::SCHEMA_DIR . '/MapiFieldsOther.yaml');
@@ -46,7 +46,7 @@ class PropertySet implements \ArrayAccess
         }
     }
     
-    protected function map()
+    protected function map(): void
     {
         //print_r($this->raw->keys());
 
@@ -116,12 +116,12 @@ class PropertySet implements \ArrayAccess
         return $val;
     }
 
-    public function set($code, $value, $guid = null)
+    public function set($code, $value, $guid = null): void
     {        
         $this->raw->set($this->resolveKey($code, $guid), $value);
     }
 
-    public function delete($code, $guid = null)
+    public function delete($code, $guid = null): void
     {
         $this->raw->delete($this->resolveKey($code, $guid));
     }
@@ -138,23 +138,27 @@ class PropertySet implements \ArrayAccess
         return $this->set($name, $value);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         //return (!is_null($this->get($offset)));
         return (!is_null($this->raw->get($this->resolveKey($offset))));
     }
 
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->set($offset, $value);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->delete($offset);
     }

--- a/src/MAPI/Property/PropertySetConstants.php
+++ b/src/MAPI/Property/PropertySetConstants.php
@@ -12,9 +12,9 @@ class PropertySetConstants
 	// these guids are all defined with the macro DEFINE_OLEGUID in mapiguid.h.
     // see http://doc.ddart.net/msdn/header/include/mapiguid.h.html
     
-    const OLE_GUID = '{${prefix}-0000-0000-c000-000000000046}';
+    public const OLE_GUID = '{${prefix}-0000-0000-c000-000000000046}';
 
-    const NAMES = [        
+    public const NAMES = [
         '00020328' => 'PS_MAPI',
         '00020329' => 'PS_PUBLIC_STRINGS',
         '00020380' => 'PS_ROUTING_EMAIL_ADDRESSES',

--- a/src/MAPI/Property/PropertyStore.php
+++ b/src/MAPI/Property/PropertyStore.php
@@ -42,7 +42,7 @@ class PropertyStore
         }
     }
 
-    protected function load(Element $obj)
+    protected function load(Element $obj): void
     {
 
         //# find name_id first
@@ -75,7 +75,10 @@ class PropertyStore
 
     }
 
-    protected function parseNameId($obj)
+    /**
+     * @return array<PropertyKey>
+     */
+    protected function parseNameId($obj): array
     {
         // $remaining = clone $obj->getChildren()
 
@@ -170,7 +173,7 @@ class PropertyStore
 
     }
 
-    protected function parseSubstg($key, $encoding, $offset, $obj)
+    protected function parseSubstg($key, $encoding, $offset, $obj): void
     {
         $MULTIVAL = 0x1000;
         
@@ -209,7 +212,7 @@ class PropertyStore
 
     //# For parsing the +properties+ file. Smaller properties are serialized in one chunk,
     //# such as longs, bools, times etc. The parsing has problems.
-    protected function parseProperties($obj)
+    protected function parseProperties($obj): void
     {
         $data = $obj->getData();
         $pad  = $obj->getSize() % 16;
@@ -226,7 +229,7 @@ class PropertyStore
             
             // copying ruby implementation's oddness to avoid any endianess issues
             $rawData = unpack('V', $rawProp)[1];
-            list($property, $encoding) = str_split(sprintf('%08x', $rawData), 4);
+            [$property, $encoding] = str_split(sprintf('%08x', $rawData), 4);
             $key = hexdec($property);
 
             //# doesn't make any sense to me. probably because its a serialization of some internal
@@ -370,7 +373,7 @@ class PropertyStore
         
     }
 
-    protected function addProperty($key, $value, $pos = null)
+    protected function addProperty($key, $value, $pos = null): void
     {
         
         

--- a/src/MAPI/Property/PropertyStoreEncodings.php
+++ b/src/MAPI/Property/PropertyStoreEncodings.php
@@ -6,39 +6,39 @@ use Hfig\MAPI\OLE\CompoundDocumentElement as Element;
 
 class PropertyStoreEncodings
 {
-    const ENCODERS = [
+    public const ENCODERS = [
         0x000d => 'decode0x000d',
         0x001f => 'decode0x001f',
         0x001e => 'decode0x001e',
         0x0203 => 'decode0x0102',
     ];
 
-    static public function decode0x000d(Element $e)
+    public static function decode0x000d(Element $e):Element
     {
         return $e;
     }
 
-    static public function decode0x001f(Element $e)
+    public static function decode0x001f(Element $e)
     {
         return mb_convert_encoding( $e->getData(), 'UTF-8', 'UTF-16LE');
     }
 
-    static public function decode0x001e(Element $e)
+    public static function decode0x001e(Element $e)
     {
         return trim($e->getData());
     }
 
-    static public function decode0x0102(Element $e)
+    public static function decode0x0102(Element $e)
     {
         return $e->getData();
     }
 
-    static public function decodeUnknown(Element $e)
+    public static function decodeUnknown(Element $e)
     {
         return $e->getData();
     }
 
-    static public function decode($encoding, Element $e)
+    public static function decode($encoding, Element $e)
     {
         if (isset(self::ENCODERS[$encoding])) {
             $fn = self::ENCODERS[$encoding];
@@ -48,7 +48,7 @@ class PropertyStoreEncodings
 
     }
 
-    static public function getDecoder($encoding)
+    public static function getDecoder($encoding)
     {
         if (isset(self::ENCODERS[$encoding])) {
             $fn = self::ENCODERS[$encoding];
@@ -57,7 +57,7 @@ class PropertyStoreEncodings
         return self::decodeUnknown;
     }
 
-    static public function decodeFunction($encoding, Element $e)
+    public static function decodeFunction($encoding, Element $e)
     {
         return function() use ($encoding, $e) {
             return PropertyStoreEncodings::decode($encoding, $e);


### PR DESCRIPTION
As a replacement for #40, I have created this PR to add return types wherever it was possible.

This should add the return types as added by the interface as well.

For the ones of the interface where it was not possible (because mixed doesn't exist yet on 7.1), we add it with in a docblock with a ReturnTypeWillChange-attribute.

Additionally, I changed some instances of "static public function foo()" to "public static function foo()".

Finally I added "public" to all constants which were public implicitly.

### Dev-dependency
I added pear/pear-core-minimal as a dev-dependency because otherwise I was not able to run the unit-tests, although this will probably be fixed in [pear/OLE#33](https://github.com/pear/OLE/pull/33).