### PR TITLE
Add Support to Yaml 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-bcmath": "*",
         "ext-mbstring": "*",
         "pear/ole": "^1.0",
-        "symfony/yaml": "^4.1||^5.0||^6.0||^7.0",
+        "symfony/yaml": "^3.4||^4.1||^5.0||^6.0||^7.0",
         "ramsey/uuid": "^3.8||^4.0",
         "psr/log": "^1.0||^2.0||^3.0"
     },


### PR DESCRIPTION
Hello,
Thank you for this awesome library.

I'm trying to get it work with a Symfony 3.4 project, and since yaml is packaged with Symfony 3.4, the library cannot coexist with it since it doesn't allow Yaml 3.4.

Can I extend the version of yaml to support version 3.4. I tested it and it's working fine.

Thank you!